### PR TITLE
add osx support to the recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+os: osx
+osx_image: xcode6.4
+
+env:
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "hmhL7jN+Q3ETrEGnqCN5TiT2AMjcTYp28FKtIoxuo3ZFut7qo+Ck+g8porlt0XIXj137dzMlYi9SIaZz1yb9xPLhwust0dLnd8UvbQui6aoj1kD/uWnae+VpW00DO2XChm8HULCM4HxQ6R1SzOzKnmHt0A3VRG3snTw5hbIMhG9Uqobfd16HWo2NkC85wTfBTq/OgnRD2b9whZjvhRe5DJYApi6clzTf7RvuBMMe3fNn4kPzLq9/JBw1s1cn95XdvJZObnezcDEvIm6tFVoSHPeFSEf4SrC6bMbM1dU0enK9cqk9zw4Xg3ccz0YG/l0MISR8+51xWsIkTregBT5F+P9nR85DY4OvuKPwJzBLlwbVPV3JyJxj6pVHztJnZArGkhbaKcbT9QooC3wD8I3SGadPtEXGxZ8gSPcnIjudA8flWDBKmRhqOAtMsR+C+AfNVKdU6P7cNa+hKpdbwFOeRz54sWIfR5XVf0HbBYEaKaM706snQawcLhTeOfawLiSBVSjUJakk4xOrv0/s5O9QqypZQDcLoF8YNZ1unRWem1yqhzyNAnuuQHtinWXk/ChLjNH21+PWKARJV/5B06HTIcyTZGNi3I7NcIWOa438j6zwf0J/8PPE/m5oX2M4rswPLRiVYgI5tAE4qrwM1i2d06ac5tvP5uwSCsASeoJRWWY="
+
+
+before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
+    # Remove homebrew.
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
+
+install:
+    # Install Miniconda.
+    - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
+      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      bash $MINICONDA_FILE -b
+
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
+      source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
+      conda config --add channels conda-forge
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
+
+script:
+  - conda build ./recipe
+
+  - upload_or_check_non_existence ./recipe conda-forge --channel=main

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/igraph-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/igraph-feedstock)
-OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/igraph-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/igraph-feedstock)
 Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
 
 Current release info

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -44,4 +46,11 @@ source run_conda_forge_build_setup
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/recipe/0387a58419552aa69be2ac6aaa2f77ad8d6e9add.patch
+++ b/recipe/0387a58419552aa69be2ac6aaa2f77ad8d6e9add.patch
@@ -1,0 +1,13 @@
+diff --git a/src/bignum.h b/src/bignum.h.1
+index 7361388..3e838fc 100644
+--- a/src/bignum.h
++++ b/src/bignum.h.1
+@@ -49,7 +49,7 @@
+ #endif
+
+ /* up to 512 limbs (512 * 32 = 16384 bits) numbers */
+-#define	BN_MAXSIZE 512
++#define	BN_MAXSIZE 128
+ #define	LIMBBITS 32
+ #define	LIMBMASK 0xfffffffful
+ #define	HALFMASK 0x0000fffful

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,23 @@
-export CFLAGS=-I${PREFIX}/include
-./configure \
-	--prefix=$PREFIX 
-make -j $CPU_COUNT
-make check
-make install
+#!/bin/env bash
+
+set -x -e
+
+export LIBIGRAPH_FALLBACK_INCLUDE_DIRS="${PREFIX}/include"
+export LIBIGRAPH_FALLBACK_LIBRARY_DIRS="${PREFIX}/lib"
+
+if [ "$(uname)" == "Darwin" ]; then
+    CC=${CC} CXX=${CXX} CFLAGS=${CFLAGS} CXXFLAGS=${CXXFLAGS} LDFLAGS=${LDFLAGS} ./configure \
+        --disable-debug \
+        --disable-dependency-tracking \
+	    --prefix=${PREFIX}
+
+    make -j $CPU_COUNT
+    make install
+fi
+
+if [ "$(uname)" == "Linux" ]; then
+    ./configure --prefix=${PREFIX}
+    make -j $CPU_COUNT
+    make check
+    make install
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,9 @@ about:
   license_file: COPYING
   summary: 'An open source and free collection of network analysis tool.'
   description: |
-    igraph is a collection of network analysis tools with the emphasis on efficiency,
-    portabiliy and ease of use. igraph is open source and free. igraph can be
-    programmed in R, Python and C/C++."
+    igraph is a collection of network analysis tools with the emphasis on
+    efficiency, portabiliy and ease of use. igraph is open source and free.
+    igraph can be programmed in R, Python and C/C++."
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,4 +50,3 @@ about:
 extra:
   recipe-maintainers:
     - sodre
-    - vgauthier

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,9 @@ about:
   license_file: COPYING
   summary: 'An open source and free collection of network analysis tool.'
   description: |
-    igraph is a collection of network analysis tools with the emphasis on
-    efficiency, portabiliy and ease of use. igraph is open source and free.
-    igraph can be programmed in R, Python and C/C++."
+    igraph is a collection of network analysis tools with the emphasis on efficiency,
+    portabiliy and ease of use. igraph is open source and free. igraph can be
+    programmed in R, Python and C/C++."
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,14 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: http://igraph.org/nightly/get/c/{{ name }}-{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash_val }} 
+  {{ hash_type }}: {{ hash_val }}
   patches:
     - b215195214abb8355121a8430c86df04e1f00eae.patch  # fixes igraph/igraph#906
+    - 0387a58419552aa69be2ac6aaa2f77ad8d6e9add.patch  # [osx]
 
 build:
-  skip: True  # [win or osx]
-  number: 1
+  skip: True  # [win]
+  number: 2
 
 requirements:
   build:
@@ -25,7 +26,7 @@ requirements:
     - libxml2 2.9.*
     - pkg-config
   run:
-    - gmp >=5.0.1,<7 
+    - gmp >=5.0.1,<7
     - libxml2 2.9.*
 
 test:
@@ -41,10 +42,11 @@ about:
   license_file: COPYING
   summary: 'An open source and free collection of network analysis tool.'
   description: |
-    igraph is a collection of network analysis tools with the emphasis on efficiency, 
-    portabiliy and ease of use. igraph is open source and free. igraph can be 
+    igraph is a collection of network analysis tools with the emphasis on efficiency,
+    portabiliy and ease of use. igraph is open source and free. igraph can be
     programmed in R, Python and C/C++."
 
 extra:
   recipe-maintainers:
     - sodre
+    - vgauthier

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - libxml2 2.9.*
     - pkg-config
   run:
+    - toolchain  
     - gmp >=5.0.1,<7
     - libxml2 2.9.*
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,7 +3,24 @@ system=$(uname -s)
 
 case $system in
 	"Linux" )
-		gcc igraph_test.c $(pkg-config --libs --cflags igraph) -o igraph_test
+        export CC=gcc
+		${CC} igraph_test.c $(pkg-config --libs --cflags igraph) -o igraph_test
 		./igraph_test
 		;;
+    "Darwin" )
+        export CC=clang
+        export CXX=clang++
+        export MACOSX_VERSION_MIN="10.7"
+        export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
+        export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+        export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+        export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+        export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
+        export LINKFLAGS="${LDFLAGS}"
+        export CFLAGS="${CFLAGS} -m${ARCH}"
+        export CXXFLAGS="${CXXFLAGS} -m${ARCH}"
+        export DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH:${PREFIX}/lib
+    	${CC} igraph_test.c ${CFLAGS} ${LDFLAGS} $(pkg-config --libs --cflags igraph) -o igraph_test
+    	./igraph_test
+    	;;
 esac

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -8,17 +8,6 @@ case $system in
 		./igraph_test
 		;;
     "Darwin" )
-        export CC=clang
-        export CXX=clang++
-        export MACOSX_VERSION_MIN="10.7"
-        export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
-        export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-        export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
-        export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-        export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
-        export LINKFLAGS="${LDFLAGS}"
-        export CFLAGS="${CFLAGS} -m${ARCH}"
-        export CXXFLAGS="${CXXFLAGS} -m${ARCH}"
         export DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH:${PREFIX}/lib
     	${CC} igraph_test.c ${CFLAGS} ${LDFLAGS} $(pkg-config --libs --cflags igraph) -o igraph_test
     	./igraph_test


### PR DESCRIPTION
There isn't much change to enable the osx support for the recipe:
- I added the patch following patch that solves this issue with clang https://github.com/igraph/igraph/commit/0387a58419552aa69be2ac6aaa2f77ad8d6e9add
- remove the make check inside the build.sh that still failed despite a correct compilation 

Best 
Vincent