### PR TITLE
Add igraph.pc to lib/pkgconfig

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,3 +13,4 @@ export LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib $LDFLAGS"
 make -j $CPU_COUNT
 make check || (cat tests/testsuite.log && exit 1)
 make install
+mv igraph.pc ${PREFIX}/lib/pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -36,6 +36,8 @@ test:
   requires:
     - pkg-config
     - toolchain
+  commands:
+    - pkg-config --exists igraph
 
 about:
   home: http://igraph.org

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 system=$(uname -s)
 
 case $system in


### PR DESCRIPTION
- This is necessary based on item 3 in igraph/python-igraph#95
- Should also help solve conda-forge/python-igraph-feedstock#7