### PR TITLE
fix: List BLAS/LAPACK run requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 11ac87336b7adc61b4cb3d9c29fd9ed74db383a1fd994f6c47a870a86f68038c
 build:
   skip: true  # [win and vc<14]
-  number: 3
+  number: 4
   script_env:
     - F2C_EXTERNAL_ARITH_HEADER={{ RECIPE_DIR }}/arith_arm64.h  # [arm64]
 
@@ -45,6 +45,8 @@ requirements:
     - arpack  # [not win]
     - gmp  # [not win]
     - mpir  # [win]
+    - libblas
+    - liblapack
 
 test:
   files:


### PR DESCRIPTION
For some reason the BLAS/LAPACK run requirements weren't correctly exported. As far as I understand, they should actually be exported.