### PR TITLE
fix: List BLAS/LAPACK run requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 5f72398c7847bb167f85159b7a9fe1fe69ce0f241c5de5d30b2b347f9dc3f7c6
 build:
   skip: true  # [win and vc<14]
-  number: 0
+  number: 1
   script_env:
     - F2C_EXTERNAL_ARITH_HEADER={{ RECIPE_DIR }}/arith_arm64.h  # [arm64]
 
@@ -45,6 +45,8 @@ requirements:
     - arpack  # [not win]
     - gmp  # [not win]
     - mpir  # [win]
+    - libblas
+    - liblapack
 
 test:
   files:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Previously `libblas` and `liblapack` weren't listed as `run` requirements. This might have lead to issues with missing dependencies downstream (see [this build](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=692825&view=logs&jobId=240f1fee-52bc-5498-a14a-8361bde76ba0) for https://github.com/conda-forge/staged-recipes/pull/22615). 

This was presumably not detected earlier because these were also requirements in other dependencies of packages that build on `igraph` directly.

<!--
Please add any other relevant info below:
-->
