### PR TITLE
Fix/run-requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 5f72398c7847bb167f85159b7a9fe1fe69ce0f241c5de5d30b2b347f9dc3f7c6
 build:
   skip: true  # [win and vc<14]
-  number: 1
+  number: 0
   script_env:
     - F2C_EXTERNAL_ARITH_HEADER={{ RECIPE_DIR }}/arith_arm64.h  # [arm64]
 
@@ -45,8 +45,6 @@ requirements:
     - arpack  # [not win]
     - gmp  # [not win]
     - mpir  # [win]
-    - libblas
-    - liblapack
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 5f72398c7847bb167f85159b7a9fe1fe69ce0f241c5de5d30b2b347f9dc3f7c6
 build:
   skip: true  # [win and vc<14]
-  number: 0
+  number: 2
   script_env:
     - F2C_EXTERNAL_ARITH_HEADER={{ RECIPE_DIR }}/arith_arm64.h  # [arm64]
 
@@ -45,6 +45,11 @@ requirements:
     - arpack  # [not win]
     - gmp  # [not win]
     - mpir  # [win]
+    # We explicitly do not list libblas and liblapack here because they are
+    # specified automatically correctly, and can be changed to other
+    # implementations.
+    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#blas
+    # for more details
 
 test:
   files:


### PR DESCRIPTION
Apologies, it seems I was mistaken about `libblas` and `liblapack`, and this PR essentially reverts https://github.com/conda-forge/igraph-feedstock/pull/49. See https://conda-forge.org/docs/maintainer/knowledge_base.html#blas for more details. 